### PR TITLE
Introduce type field

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,24 @@ is required:
 
 The instansiated object has the following properties:
 
+### type
+
+A hint of what type of metric this is.
+
+ * Valid values: `Number` in the range of `0-7`.
+ * Value is imutable.
+
+Each numeric value reflect one of the following types:
+
+ * `0` represents `unknown`.
+ * `1` represents `gauge`.
+ * `2` represents `counter`.
+ * `3` represents `state_set`.
+ * `4` represents `info`.
+ * `5` represents `cumulative histogram`.
+ * `6` represents `gauge histogram`.
+ * `7` represents `summary`.
+
 ### name
 
 The name of the metric.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The instansiated object has the following properties:
 A hint of what type of metric this is.
 
  * Valid values: `Number` in the range of `0-7`.
- * Value is imutable.
+ * Value is immutable.
 
 Each numeric value reflect one of the following types:
 
@@ -80,14 +80,14 @@ Each numeric value reflect one of the following types:
 The name of the metric.
 
  * Valid characters: `a-z,A-Z,0-9,_`.
- * Value is imutable.
+ * Value is immutable.
 
 ### value
 
 The value of the metric.
 
  * Valid values: `Number` or `String`.
- * Value is imutable.
+ * Value is immutable.
 
 ### source
 
@@ -101,21 +101,21 @@ The source of the metric in terms of where it originated.
 A human readable description of the metric.
 
  * Valid values: `String`.
- * Value is imutable.
+ * Value is immutable.
 
 ### timestamp
 
 A timestamp of when the metric was created.
 
  * Valid values: `Number`.
- * Value is imutable.
+ * Value is immutable.
 
 ### time
 
 N/A.
 
  * Valid values: `Number`.
- * Value is imutable.
+ * Value is immutable.
 
 ### meta
 
@@ -124,4 +124,4 @@ a way to label metrics. Use each key of the meta object as the label name and
 the value as the label value.
 
  * Valid values: `Object`.
- * Value is imutable.
+ * Value is immutable.

--- a/lib/metric.js
+++ b/lib/metric.js
@@ -20,6 +20,10 @@ const Metric = class Metric {
         this[source] = value;
     }
 
+    get type() {
+        return this[notEmpty](this[metric].type) ? this[metric].type : 0;
+    }
+
     get name() {
         return this[metric].name;
     }
@@ -49,6 +53,7 @@ const Metric = class Metric {
             name: this.name,
             description: this.description,
             timestamp: this.timestamp,
+            type: this.type,
             value: this.value,
             time: this.time,
             meta: this.meta,

--- a/test/metric.js
+++ b/test/metric.js
@@ -41,7 +41,7 @@ tap.test('stringifying includes all keys', (t) => {
     });
     t.equal(
         `${metric}`,
-        'Metric {"name":"valid_name","description":"Valid description","timestamp":12345,"value":null,"time":null,"meta":{}}',
+        'Metric {"name":"valid_name","description":"Valid description","timestamp":12345,"type":0,"value":null,"time":null,"meta":{}}',
     );
     t.end();
 });
@@ -53,6 +53,7 @@ tap.test('omitting required keys results in undefined instead of "null"', (t) =>
     t.equal(metric.name, 'valid_name');
     t.equal(metric.description, undefined);
     t.equal(metric.timestamp, undefined);
+    t.equal(metric.type, 0);
     t.equal(metric.time, null);
     t.equal(metric.value, null);
     t.same(metric.meta, {});
@@ -63,9 +64,11 @@ tap.test('the number 0 is treated as a number and does not yeld "null"', (t) => 
     const metric = new Metric({
         name: 'valid_name',
         value: 0,
+        type: 0,
         timestamp: 0,
     });
     t.equal(metric.timestamp, 0);
+    t.equal(metric.type, 0);
     t.equal(metric.value, 0);
     t.end();
 });
@@ -104,6 +107,7 @@ tap.test('util.inspect includes all keys', (t) => {
     const result = `Metric { name: 'valid_name',
   description: 'Valid description',
   timestamp: 12345,
+  type: 0,
   value: 123,
   time: 12345,
   meta: { key: 'value' } }`;


### PR DESCRIPTION
Introduces a `type` field in the metric object. This will help us indentify which type of metric this might be. Its intended to be a hint to the collector aggregating the metrics from the client which created the metric.

The different metric types is picked from the suggested proposal at OpenMetrics: https://github.com/OpenObservability/OpenMetrics/blob/richih/proto/openmetrics.proto#L33-L42