### PR TITLE
Validate object properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ This class definition is prefered over object literals when exchanging data over
 object. All undefined properties will have a `null` value, making sure they are kept
 when serialized to JSON.
 
+The metric object aim to be compatible with the [Open Metrics](https://github.com/OpenObservability/OpenMetrics)
+initiative.
+
 ## Constructor
 
 Create a new Metric instance.
@@ -53,18 +56,45 @@ An object literal reflecting the properties of this class. The following propert
 is required:
 
  * **name** - `String` - The name of the metric.
- * **value** - `String|Number` - The value of the metric.
+ * **description** - `String` - The description of the metric.
+
+Each property value is validated and will throw is a property value is found to be invalid.
 
 ## Properties
 
 The instansiated object has the following properties:
 
+### name
+
+The name of the metric.
+
+ * Valid value: `String` in the range of `[a-zA-Z_][a-zA-Z0-9_]`.
+ * Value is immutable.
+ * Is required.
+
+### description
+
+A human readable description of the metric.
+
+ * Valid value: `String`.
+ * Value is immutable.
+ * Is required.
+
+### value
+
+The value of the metric.
+
+ * Valid value: `Integer` or `null`.
+ * Value is immutable.
+ * Defaults to `null`.
+
 ### type
 
 A hint of what type of metric this is.
 
- * Valid values: `Number` in the range of `0-7`.
+ * Valid value: `Integer` in the range of `0-7`.
  * Value is immutable.
+ * Defaults to `0`.
 
 Each numeric value reflect one of the following types:
 
@@ -77,53 +107,57 @@ Each numeric value reflect one of the following types:
  * `6` represents `gauge histogram`.
  * `7` represents `summary`.
 
-### name
-
-The name of the metric.
-
- * Valid characters: `a-z,A-Z,0-9,_`.
- * Value is immutable.
-
-### value
-
-The value of the metric.
-
- * Valid values: `Number` or `String`.
- * Value is immutable.
-
 ### source
 
 The source of the metric in terms of where it originated.
 
- * Valid characters: `a-z,A-Z,0-9,_`.
+ * Valid value: `String` or `null`.
  * Value is mutable.
-
-### description
-
-A human readable description of the metric.
-
- * Valid values: `String`.
- * Value is immutable.
+ * Defaults to `null`.
 
 ### timestamp
 
 A timestamp of when the metric was created.
 
- * Valid values: `Number`.
+ * Valid value: `Double` - epoc milliseconds.
  * Value is immutable.
+ * Defaults to `Date.now() / 1000`.
 
-### time
+### labels
 
-N/A.
+A `Array` of labeled values. Each item in the `Array` must be an
+`Label` object. Please see the Labels section for further info.
 
- * Valid values: `Number`.
+ * Valid value: `Array` of `Label` objects.
  * Value is immutable.
+ * Defaults to an empty `Array`.
 
 ### meta
 
-Available to be used to hold any misc data.	In practice, meta can be used as
-a way to label metrics. Use each key of the meta object as the label name and
-the value as the label value.
+Available to be used to hold any data. The input is not validated.
 
- * Valid values: `Object`.
+ * Valid value: `any`.
  * Value is immutable.
+ * Default to `null`.
+
+### time
+
+Is deprecated.
+
+## Label object
+
+A `Label` object is a object literal which have the following properties:
+
+### name
+
+The name of the label.
+
+ * Valid value: `String` in the range of `[a-zA-Z0-9_]`.
+ * Is required.
+
+### value
+
+The value of the label.
+
+ * Valid value: `Integer` or `null`.
+ * Is required.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This class definition is prefered over object literals when exchanging data over
 object. All undefined properties will have a `null` value, making sure they are kept
 when serialized to JSON.
 
-The metric object aim to be compatible with the [Open Metrics](https://github.com/OpenObservability/OpenMetrics)
+The metric object aims to be compatible with the [Open Metrics](https://github.com/OpenObservability/OpenMetrics)
 initiative.
 
 ## Constructor
@@ -58,7 +58,7 @@ is required:
  * **name** - `String` - The name of the metric.
  * **description** - `String` - The description of the metric.
 
-Each property value is validated and will throw is a property value is found to be invalid.
+Each property value is validated and will throw if a property value is found to be invalid.
 
 ## Properties
 
@@ -125,7 +125,7 @@ A timestamp of when the metric was created.
 
 ### labels
 
-A `Array` of labeled values. Each item in the `Array` must be an
+An `Array` of labeled values. Each item in the `Array` must be a
 `Label` object. Please see the Labels section for further info.
 
  * Valid value: `Array` of `Label` objects.

--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -17,16 +17,23 @@ const add = (name, fn) => {
 
 const now = Date.now();
 
-add('new Metric()', () => {
+add('new Metric() - Cached timestamp', () => {
     const m = new Metric({
         name: 'foo',
-        description: 'foobar',
+        description: 'foo_bar',
         timestamp: now,
     });
 });
 
+add('new Metric() - Create timestamp', () => {
+    const m = new Metric({
+        name: 'foo',
+        description: 'foo_bar',
+    });
+});
+
 suite
-    .on('cycle', ev => {
+    .on('cycle', (ev) => {
         console.log(ev.target.toString());
         if (ev.target.error) {
             console.error(ev.target.error);

--- a/lib/is.js
+++ b/lib/is.js
@@ -1,18 +1,18 @@
 'use strict';
 
 // Ref; https://github.com/OpenObservability/OpenMetrics/blob/1dcecc569894abef6b67037b5e14f1813c7b84d7/metric_exposition_format.md
-const REGEX_NAME = /[a-zA-Z_][a-zA-Z0-9_]*/;
-const REGEX_LABEL_NAME = /[a-zA-Z0-9_]*/;
+const REGEX_NAME = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+const REGEX_LABEL = /^[a-zA-Z0-9_]*$/;
 
 const isString = (value) => {
     return (typeof value === 'string');
-}
+};
 module.exports.isString = isString;
 
 
 const isEmptyString = (value) => {
     return (value.trim().length === 0);
-}
+};
 module.exports.isEmptyString = isEmptyString;
 
 
@@ -41,6 +41,60 @@ module.exports.validName = validName;
 
 
 const validType = (value) => {
-    return (0 <= value && value <= 7);
+    return (value >= 0 && value <= 7);
 };
 module.exports.validType = validType;
+
+
+const validDescription = (value) => {
+    return isString(value) || value === null || value === undefined;
+};
+module.exports.validDescription = validDescription;
+
+
+const validSource = (value) => {
+    return isString(value) || value === null || value === undefined;
+};
+module.exports.validSource = validSource;
+
+
+const validTimestamp = (value) => {
+    return Number.isFinite(value) || value === null || value === undefined;
+};
+module.exports.validTimestamp = validTimestamp;
+
+
+const validValue = (value) => {
+    return Number.isSafeInteger(value) || value === null || value === undefined;
+};
+module.exports.validValue = validValue;
+
+
+const validLabel = (value) => {
+    if (!value.name || !value.value) {
+        return false;
+    }
+
+    if (!REGEX_LABEL.test(value.name)) {
+        return false;
+    }
+
+    return validValue(value.value);
+};
+module.exports.validLabel = validLabel;
+
+
+const validLabels = (value) => {
+    if (!Array.isArray(value)) {
+        return false;
+    }
+
+    if (value.length === 0) {
+        return true;
+    }
+
+    const valid = value.filter(validLabel).length;
+
+    return (value.length === valid);
+};
+module.exports.validLabels = validLabels;

--- a/lib/is.js
+++ b/lib/is.js
@@ -1,8 +1,7 @@
 'use strict';
 
-// Ref; https://github.com/OpenObservability/OpenMetrics/blob/1dcecc569894abef6b67037b5e14f1813c7b84d7/metric_exposition_format.md
-const REGEX_NAME = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
-const REGEX_LABEL = /^[a-zA-Z0-9_]*$/;
+// Ref; https://github.com/OpenObservability/OpenMetrics/blob/9a6db2a94dcf8dd84dd08a221e1b323e2b279f08/proto/openmetrics_data_model.proto#L42
+const REGEX_NAME = /^[a-zA-Z_:][a-zA-Z0-9_:]*$/;
 
 const isString = (value) => {
     return (typeof value === 'string');
@@ -75,7 +74,7 @@ const validLabel = (value) => {
         return false;
     }
 
-    if (!REGEX_LABEL.test(value.name)) {
+    if (!REGEX_NAME.test(value.name)) {
         return false;
     }
 

--- a/lib/is.js
+++ b/lib/is.js
@@ -1,0 +1,46 @@
+'use strict';
+
+// Ref; https://github.com/OpenObservability/OpenMetrics/blob/1dcecc569894abef6b67037b5e14f1813c7b84d7/metric_exposition_format.md
+const REGEX_NAME = /[a-zA-Z_][a-zA-Z0-9_]*/;
+const REGEX_LABEL_NAME = /[a-zA-Z0-9_]*/;
+
+const isString = (value) => {
+    return (typeof value === 'string');
+}
+module.exports.isString = isString;
+
+
+const isEmptyString = (value) => {
+    return (value.trim().length === 0);
+}
+module.exports.isEmptyString = isEmptyString;
+
+
+const notEmpty = (value) => {
+    if (value === undefined) {
+        return false;
+    }
+
+    if (value === null) {
+        return false;
+    }
+
+    if (isString(value) && isEmptyString(value)) {
+        return false;
+    }
+
+    return true;
+};
+module.exports.notEmpty = notEmpty;
+
+
+const validName = (value) => {
+    return REGEX_NAME.test(value);
+};
+module.exports.validName = validName;
+
+
+const validType = (value) => {
+    return (0 <= value && value <= 7);
+};
+module.exports.validType = validType;

--- a/lib/metric.js
+++ b/lib/metric.js
@@ -1,64 +1,50 @@
 'use strict';
 
-const assert = require('assert');
 const util = require('util');
 const is = require('./is');
 
 const _description = Symbol('metric:key:description');
 const _timestamp = Symbol('metric:key:timestamp');
 const _source = Symbol('metric:key:source');
+const _labels = Symbol('metric:key:labels');
 const _value = Symbol('metric:key:value');
-const _time = Symbol('metric:key:time');
 const _meta = Symbol('metric:key:meta');
 const _type = Symbol('metric:key:type');
 const _name = Symbol('metric:key:name');
 
 const Metric = class Metric {
     constructor({
-        name = null,
-        description = undefined,
-        timestamp = undefined,
-        type = 0,
+        description,
+        timestamp = null,
         source = null,
+        labels = [],
         value = null,
-        time = null,
-        meta = {},
+        meta = null,
+        type = 0,
+        name,
     } = {}) {
-        assert(is.validName(name), '"name" contain illegal character(s)');
-        assert(is.validType(type), '"type" must be a Number between 0 and 7');
+        // Required arguments
+        if (!name) throw new Error('The argument "name" must be provided');
+        if (!description) throw new Error('The argument "description" must be provided');
 
-        Object.defineProperty(this, _name, {
-            value: name,
-        });
+        // Validation
+        if (!is.validDescription(description)) throw new Error('Provided value to argument "description" is not legal');
+        if (!is.validTimestamp(timestamp)) throw new Error('Provided value to argument "timestamp" is not legal');
+        if (!is.validSource(source)) throw new Error('Provided value to argument "source" is not legal');
+        if (!is.validLabels(labels)) throw new Error('Provided value to argument "label" is not legal');
+        if (!is.validValue(value)) throw new Error('Provided value to argument "value" is not legal');
+        if (!is.validType(type)) throw new Error('Provided value to argument "type" is not legal');
+        if (!is.validName(name)) throw new Error('Provided value to argument "name" is not legal');
 
-        Object.defineProperty(this, _description, {
-            value: description,
-        });
-
-        Object.defineProperty(this, _timestamp, {
-            value: timestamp,
-        });
-
-        Object.defineProperty(this, _source, {
-            writable: true,
-            value: is.notEmpty(source) ? source : null,
-        });
-
-        Object.defineProperty(this, _type, {
-            value: type,
-        });
-
-        Object.defineProperty(this, _value, {
-            value: is.notEmpty(value) ? value : null,
-        });
-
-        Object.defineProperty(this, _time, {
-            value: time,
-        });
-
-        Object.defineProperty(this, _meta, {
-            value: meta,
-        });
+        // Private properties
+        this[_description] = description;
+        this[_timestamp] = timestamp || Date.now() / 1000;
+        this[_source] = is.notEmpty(source) ? source : null;
+        this[_labels] = labels;
+        this[_value] = is.notEmpty(value) ? value : null;
+        this[_meta] = meta;
+        this[_type] = type;
+        this[_name] = name;
     }
 
     get source() {
@@ -89,8 +75,8 @@ const Metric = class Metric {
         return this[_value];
     }
 
-    get time() {
-        return this[_time];
+    get labels() {
+        return this[_labels];
     }
 
     get meta() {
@@ -104,7 +90,7 @@ const Metric = class Metric {
             timestamp: this.timestamp,
             type: this.type,
             value: this.value,
-            time: this.time,
+            labels: this.labels,
             meta: this.meta,
         };
     }

--- a/lib/metric.js
+++ b/lib/metric.js
@@ -1,51 +1,100 @@
 'use strict';
 
+const assert = require('assert');
 const util = require('util');
+const is = require('./is');
 
-const metric = Symbol('metric');
-const source = Symbol('source');
-const notEmpty = Symbol('empty');
+const _description = Symbol('metric:key:description');
+const _timestamp = Symbol('metric:key:timestamp');
+const _source = Symbol('metric:key:source');
+const _value = Symbol('metric:key:value');
+const _time = Symbol('metric:key:time');
+const _meta = Symbol('metric:key:meta');
+const _type = Symbol('metric:key:type');
+const _name = Symbol('metric:key:name');
 
 const Metric = class Metric {
-    constructor(metricObj) {
-        this[metric] = metricObj;
-        this[source] = '';
+    constructor({
+        name = null,
+        description = undefined,
+        timestamp = undefined,
+        type = 0,
+        source = null,
+        value = null,
+        time = null,
+        meta = {},
+    } = {}) {
+        assert(is.validName(name), '"name" contain illegal character(s)');
+        assert(is.validType(type), '"type" must be a Number between 0 and 7');
+
+        Object.defineProperty(this, _name, {
+            value: name,
+        });
+
+        Object.defineProperty(this, _description, {
+            value: description,
+        });
+
+        Object.defineProperty(this, _timestamp, {
+            value: timestamp,
+        });
+
+        Object.defineProperty(this, _source, {
+            writable: true,
+            value: is.notEmpty(source) ? source : null,
+        });
+
+        Object.defineProperty(this, _type, {
+            value: type,
+        });
+
+        Object.defineProperty(this, _value, {
+            value: is.notEmpty(value) ? value : null,
+        });
+
+        Object.defineProperty(this, _time, {
+            value: time,
+        });
+
+        Object.defineProperty(this, _meta, {
+            value: meta,
+        });
     }
 
     get source() {
-        return this[source];
+        return this[_source];
     }
 
     set source(value) {
-        this[source] = value;
+        this[_source] = value;
     }
 
     get type() {
-        return this[notEmpty](this[metric].type) ? this[metric].type : 0;
+        return this[_type];
     }
 
     get name() {
-        return this[metric].name;
+        return this[_name];
     }
 
     get description() {
-        return this[metric].description;
+        return this[_description];
     }
 
     get timestamp() {
-        return this[metric].timestamp;
+        return this[_timestamp];
     }
 
     get value() {
-        return this[notEmpty](this[metric].value) ? this[metric].value : null;
+        return this[_value];
     }
 
     get time() {
-        return this[notEmpty](this[metric].time) ? this[metric].time : null;
+        return this[_time];
     }
 
     get meta() {
-        return this[metric].meta || {};
+        return this[_meta];
     }
 
     toJSON() {
@@ -73,22 +122,6 @@ const Metric = class Metric {
 
     get [Symbol.toStringTag]() {
         return 'Metric';
-    }
-
-    [notEmpty](value) {
-        if (value === undefined) {
-            return false;
-        }
-
-        if (value === null) {
-            return false;
-        }
-
-        if (typeof value === 'string' && value.trim().length === 0) {
-            return false;
-        }
-
-        return true;
     }
 };
 

--- a/lib/metric.js
+++ b/lib/metric.js
@@ -21,7 +21,7 @@ const Metric = class Metric {
         labels = [],
         value = null,
         time = null,
-        meta = null,
+        meta = {},
         type = 0,
         name,
     } = {}) {

--- a/lib/metric.js
+++ b/lib/metric.js
@@ -8,6 +8,7 @@ const _timestamp = Symbol('metric:key:timestamp');
 const _source = Symbol('metric:key:source');
 const _labels = Symbol('metric:key:labels');
 const _value = Symbol('metric:key:value');
+const _time = Symbol('metric:key:time');
 const _meta = Symbol('metric:key:meta');
 const _type = Symbol('metric:key:type');
 const _name = Symbol('metric:key:name');
@@ -19,6 +20,7 @@ const Metric = class Metric {
         source = null,
         labels = [],
         value = null,
+        time = null,
         meta = null,
         type = 0,
         name,
@@ -45,6 +47,9 @@ const Metric = class Metric {
         this[_meta] = meta;
         this[_type] = type;
         this[_name] = name;
+
+        // Deprecated
+        this[_time] = is.notEmpty(time) ? time : null;
     }
 
     get source() {
@@ -79,6 +84,10 @@ const Metric = class Metric {
         return this[_labels];
     }
 
+    get time() {
+        return this._time;
+    }
+
     get meta() {
         return this[_meta];
     }
@@ -91,6 +100,7 @@ const Metric = class Metric {
             type: this.type,
             value: this.value,
             labels: this.labels,
+            time: this.time,
             meta: this.meta,
         };
     }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.14.0",
     "benchmark": "^2.1.4",
+    "lolex": "^3.0.0",
     "tap": "^12.1.1"
   }
 }

--- a/test/is.js
+++ b/test/is.js
@@ -3,45 +3,220 @@
 const tap = require('tap');
 const is = require('../lib/is');
 
+tap.test('is.isString() - is a String - should return true', (t) => {
+    t.true(is.isString('aa'));
+    t.true(is.isString(''));
+    t.true(is.isString('10'));
+    t.true(is.isString('true'));
+    t.true(is.isString('[1]'));
+    t.end();
+});
+
+tap.test('is.isString() - not a String - should return false', (t) => {
+    t.false(is.isString(NaN));
+    t.false(is.isString(10));
+    t.false(is.isString({ foo: 1 }));
+    t.false(is.isString(true));
+    t.false(is.isString([1]));
+    t.end();
+});
+
+tap.test('is.isEmptyString() - is a empty String - should return true', (t) => {
+    t.true(is.isEmptyString(''));
+    t.true(is.isEmptyString('  ')); // spaces
+    t.true(is.isEmptyString('   ')); // tab
+    t.true(is.isEmptyString('\n')); // newline
+    t.end();
+});
+
+tap.test('is.isEmptyString() - not an empty String - should return false', (t) => {
+    t.false(is.isEmptyString('a'));
+    t.false(is.isEmptyString('  a    '));
+    t.end();
+});
+
+tap.test('is.notEmpty() - is not empty - should return true', (t) => {
+    t.true(is.notEmpty('a'));
+    t.true(is.notEmpty('undefined'));
+    t.true(is.notEmpty('  a    '));
+    t.true(is.notEmpty('null'));
+    t.end();
+});
+
+tap.test('is.notEmpty() - is empty - should return false', (t) => {
+    t.false(is.notEmpty());
+    t.false(is.notEmpty(undefined));
+    t.false(is.notEmpty(null));
+    t.false(is.notEmpty(''));
+    t.false(is.notEmpty('  ')); // spaces
+    t.false(is.notEmpty('   ')); // tab
+    t.false(is.notEmpty('\n')); // newline
+    t.end();
+});
+
 tap.test('is.validName() - has chars in the specter of [a-zA-Z_][a-zA-Z0-9_]* - should return true', (t) => {
-    const result = is.validName('abc_def_G_01');
-    t.true(result);
+    t.true(is.validName('abc_def_G_01'));
     t.end();
 });
 
 tap.test('is.validName() - value is just a number - should return false', (t) => {
-    const result = is.validName('10');
-    t.false(result);
+    t.false(is.validName('10'));
     t.end();
 });
 
 tap.test('is.validType() - value is 0 - should return true', (t) => {
-    const result = is.validType(0);
-    t.true(result);
+    t.true(is.validType(0));
     t.end();
 });
 
 tap.test('is.validType() - value is within the range of 0 and 7 - should return true', (t) => {
-    const result = is.validType(5);
-    t.true(result);
+    t.true(is.validType(5));
     t.end();
 });
 
 tap.test('is.validType() - value is 7 - should return true', (t) => {
-    const result = is.validType(7);
-    t.true(result);
+    t.true(is.validType(7));
     t.end();
 });
 
 tap.test('is.validType() - value is lower than 0 - should return false', (t) => {
-    const result = is.validType(-1);
-    t.false(result);
+    t.false(is.validType(-1));
     t.end();
 });
 
 tap.test('is.validType() - value is higher than 7 - should return false', (t) => {
-    const result = is.validType(8);
-    t.false(result);
+    t.false(is.validType(8));
     t.end();
 });
 
+tap.test('is.validDescription() - value is a String - should return true', (t) => {
+    t.true(is.validDescription('foo'));
+    t.end();
+});
+
+tap.test('is.validDescription() - value is "null" - should return true', (t) => {
+    t.true(is.validDescription(null));
+    t.end();
+});
+
+tap.test('is.validDescription() - value is "undefined" - should return true', (t) => {
+    t.true(is.validDescription(undefined));
+    t.end();
+});
+
+tap.test('is.validDescription() - value is a Number - should return false', (t) => {
+    t.false(is.validDescription(10));
+    t.end();
+});
+
+tap.test('is.validSource() - value is a String - should return true', (t) => {
+    t.true(is.validSource('foo'));
+    t.end();
+});
+
+tap.test('is.validSource() - value is "null" - should return true', (t) => {
+    t.true(is.validSource(null));
+    t.end();
+});
+
+tap.test('is.validSource() - value is "undefined" - should return true', (t) => {
+    t.true(is.validSource(undefined));
+    t.end();
+});
+
+tap.test('is.validSource() - value is a Number - should return false', (t) => {
+    t.false(is.validSource(10));
+    t.end();
+});
+
+tap.test('is.validTimestamp() - value is a Integer - should return true', (t) => {
+    t.true(is.validTimestamp(10));
+    t.end();
+});
+
+tap.test('is.validTimestamp() - value is a Double - should return true', (t) => {
+    t.true(is.validTimestamp(10.4));
+    t.end();
+});
+
+tap.test('is.validTimestamp() - value is "null" - should return true', (t) => {
+    t.true(is.validTimestamp(null));
+    t.end();
+});
+
+tap.test('is.validTimestamp() - value is "undefined" - should return true', (t) => {
+    t.true(is.validTimestamp(undefined));
+    t.end();
+});
+
+tap.test('is.validTimestamp() - value is a String - should return false', (t) => {
+    t.false(is.validTimestamp('foo'));
+    t.end();
+});
+
+tap.test('is.validValue() - value is a Integer - should return true', (t) => {
+    t.true(is.validValue(10));
+    t.end();
+});
+
+tap.test('is.validValue() - value is a Double - should return false', (t) => {
+    t.false(is.validValue(10.4));
+    t.end();
+});
+
+tap.test('is.validValue() - value is "null" - should return true', (t) => {
+    t.true(is.validValue(null));
+    t.end();
+});
+
+tap.test('is.validValue() - value is "undefined" - should return true', (t) => {
+    t.true(is.validValue(undefined));
+    t.end();
+});
+
+tap.test('is.validValue() - value is a String - should return false', (t) => {
+    t.false(is.validValue('foo'));
+    t.end();
+});
+
+tap.test('is.validLabel() - value is legal - should return true', (t) => {
+    t.true(is.validLabel({ name: 'foo', value: 10 }));
+    t.end();
+});
+
+tap.test('is.validLabel() - not a label object - should return false', (t) => {
+    t.false(is.validLabel({ bar: 'a' }));
+    t.false(is.validLabel({ name: 'a', bar: 'a' }));
+    t.false(is.validLabel({ value: 'a', bar: 'a' }));
+    t.end();
+});
+
+tap.test('is.validLabel() - value of "name" property is illegal - should return false', (t) => {
+    t.false(is.validLabel({ name: '1 foo_', value: 10 }));
+    t.end();
+});
+
+tap.test('is.validLabel() - value of "value" property is illegal - should return false', (t) => {
+    t.false(is.validLabel({ name: 'foo', value: 'bar' }));
+    t.end();
+});
+
+tap.test('is.validLabels() - value is Array with legal objects - should return true', (t) => {
+    t.true(is.validLabels([{ name: 'bar', value: 5 }, { name: 'foo', value: 10 }]));
+    t.end();
+});
+
+tap.test('is.validLabels() - value is empty Array - should return true', (t) => {
+    t.true(is.validLabels([]));
+    t.end();
+});
+
+tap.test('is.validLabels() - value is not an Array - should return false', (t) => {
+    t.false(is.validLabels('foo'));
+    t.end();
+});
+
+tap.test('is.validLabels() - value is Array with some ilegal objects - should return false', (t) => {
+    t.false(is.validLabels([{ name: 'bar', value: 5 }, { name: 'xyz', value: 'a' }, { name: 'foo', value: 10 }, 'foo']));
+    t.end();
+});

--- a/test/is.js
+++ b/test/is.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const tap = require('tap');
+const is = require('../lib/is');
+
+tap.test('is.validName() - has chars in the specter of [a-zA-Z_][a-zA-Z0-9_]* - should return true', (t) => {
+    const result = is.validName('abc_def_G_01');
+    t.true(result);
+    t.end();
+});
+
+tap.test('is.validName() - value is just a number - should return false', (t) => {
+    const result = is.validName('10');
+    t.false(result);
+    t.end();
+});
+
+tap.test('is.validType() - value is 0 - should return true', (t) => {
+    const result = is.validType(0);
+    t.true(result);
+    t.end();
+});
+
+tap.test('is.validType() - value is within the range of 0 and 7 - should return true', (t) => {
+    const result = is.validType(5);
+    t.true(result);
+    t.end();
+});
+
+tap.test('is.validType() - value is 7 - should return true', (t) => {
+    const result = is.validType(7);
+    t.true(result);
+    t.end();
+});
+
+tap.test('is.validType() - value is lower than 0 - should return false', (t) => {
+    const result = is.validType(-1);
+    t.false(result);
+    t.end();
+});
+
+tap.test('is.validType() - value is higher than 7 - should return false', (t) => {
+    const result = is.validType(8);
+    t.false(result);
+    t.end();
+});
+

--- a/test/metric.js
+++ b/test/metric.js
@@ -96,7 +96,7 @@ tap.test('Metric() - only required arguments is set - should set defaults on opt
     t.equal(metric.type, 0);
     t.same(metric.labels, []);
     t.equal(metric.source, null);
-    t.equal(metric.meta, null);
+    t.same(metric.meta, {});
 
     clock.uninstall();
 
@@ -144,7 +144,7 @@ tap.test('Metric.toJSON() - only required arguments is set - should contain all 
     t.same(serialized.labels, []);
     t.equal(serialized.value, null);
     t.equal(serialized.type, 0);
-    t.equal(serialized.meta, null);
+    t.same(serialized.meta, {});
     t.equal(metric.name, 'valid_name');
 
     clock.uninstall();
@@ -187,7 +187,7 @@ tap.test('Metric.toPrimitive() - stringify - should includes all keys', (t) => {
     });
     t.equal(
         `${metric}`,
-        'Metric {"name":"valid_name","description":"Valid description","timestamp":12345,"type":0,"value":null,"labels":[],"meta":null}',
+        'Metric {"name":"valid_name","description":"Valid description","timestamp":12345,"type":0,"value":null,"labels":[],"meta":{}}',
     );
     t.end();
 });

--- a/test/metric.js
+++ b/test/metric.js
@@ -232,6 +232,7 @@ tap.test('Metric() - util.inspect - should includes all keys', (t) => {
   type: 0,
   value: 123,
   labels: [],
+  time: undefined,
   meta: { key: 'value' } }`;
 
     t.equal(util.inspect(metric), result);

--- a/test/metric.js
+++ b/test/metric.js
@@ -2,38 +2,184 @@
 
 const util = require('util');
 const tap = require('tap');
+const lolex = require('lolex');
 const Metric = require('../lib/metric');
 
 tap.test('Metric() - object type - should be Metric', (t) => {
-    const metric = new Metric();
+    const metric = new Metric({ name: 'foo', description: 'bar' });
     t.equal(Object.prototype.toString.call(metric), '[object Metric]');
     t.end();
 });
 
-tap.test('set and get value of source', (t) => {
-    const metric = new Metric({
-        name: 'valid_name',
-        description: 'Valid description',
-        timestamp: 12345,
-    });
-    metric.source = 'foo';
-    t.equal(metric.source, 'foo');
+tap.test('Metric() - No arguments - should throw', (t) => {
+    t.plan(1);
+    t.throws(() => {
+        const metric = new Metric(); // eslint-disable-line no-unused-vars
+    }, /The argument "name" must be provided/);
     t.end();
 });
 
-tap.test('optional values return null when not provided', (t) => {
-    const metric = new Metric({
-        name: 'valid_name',
-        description: 'Valid description',
-        timestamp: 12345,
-    });
-    t.equal(metric.value, null);
-    t.equal(metric.time, null);
-    t.same(metric.meta, {});
+tap.test('Metric() - "name" argument is not provided - should throw', (t) => {
+    t.plan(1);
+    t.throws(() => {
+        const metric = new Metric({ description: 'bar' }); // eslint-disable-line no-unused-vars
+    }, /The argument "name" must be provided/);
     t.end();
 });
 
-tap.test('stringifying includes all keys', (t) => {
+tap.test('Metric() - "description" argument is not provided - should throw', (t) => {
+    t.plan(1);
+    t.throws(() => {
+        const metric = new Metric({ name: 'bar' }); // eslint-disable-line no-unused-vars
+    }, /The argument "description" must be provided/);
+    t.end();
+});
+
+tap.test('Metric() - "name" argument is not valid - should throw', (t) => {
+    t.plan(1);
+    t.throws(() => {
+        const metric = new Metric({ name: '10', description: 'bar' }); // eslint-disable-line no-unused-vars
+    }, /Provided value to argument "name" is not legal/);
+    t.end();
+});
+
+tap.test('Metric() - "timestamp" argument is not valid - should throw', (t) => {
+    t.plan(1);
+    t.throws(() => {
+        const metric = new Metric({ name: 'foo', description: 'bar', timestamp: '10' }); // eslint-disable-line no-unused-vars
+    }, /Provided value to argument "timestamp" is not legal/);
+    t.end();
+});
+
+tap.test('Metric() - "description" argument is not valid - should throw', (t) => {
+    t.plan(1);
+    t.throws(() => {
+        const metric = new Metric({ name: 'foo', description: 10, }); // eslint-disable-line no-unused-vars
+    }, /Provided value to argument "description" is not legal/);
+    t.end();
+});
+
+tap.test('Metric() - "source" argument is not valid - should throw', (t) => {
+    t.plan(1);
+    t.throws(() => {
+        const metric = new Metric({ name: 'foo', description: 'bar', source: 10 }); // eslint-disable-line no-unused-vars
+    }, /Provided value to argument "source" is not legal/);
+    t.end();
+});
+
+tap.test('Metric() - "type" argument is not valid - should throw', (t) => {
+    t.plan(1);
+    t.throws(() => {
+        const metric = new Metric({ name: 'foo', description: 'bar', type: '10' }); // eslint-disable-line no-unused-vars
+    }, /Provided value to argument "type" is not legal/);
+    t.end();
+});
+
+tap.test('Metric() - "value" argument is not valid - should throw', (t) => {
+    t.plan(1);
+    t.throws(() => {
+        const metric = new Metric({ name: 'foo', description: 'bar', value: '10' }); // eslint-disable-line no-unused-vars
+    }, /Provided value to argument "value" is not legal/);
+    t.end();
+});
+
+tap.test('Metric() - only required arguments is set - should set defaults on optional arguments', (t) => {
+    const clock = lolex.install();
+    clock.tick(1547507561724);
+
+    const metric = new Metric({
+        name: 'valid_name',
+        description: 'Valid description',
+    });
+
+    t.equal(metric.timestamp, (1547507561724 / 1000));
+    t.equal(metric.type, 0);
+    t.same(metric.labels, []);
+    t.equal(metric.source, null);
+    t.equal(metric.meta, null);
+
+    clock.uninstall();
+
+    t.end();
+});
+
+tap.test('Metric() - all arguments is set - should set on respectative property', (t) => {
+    const metric = new Metric({
+        description: 'Valid description',
+        timestamp: 1547507561724,
+        source: 'valid_source',
+        labels: [{ name: 'foo', value: 5 }],
+        value: 10,
+        meta: 'valid_meta',
+        type: 2,
+        name: 'valid_name',
+    });
+
+    t.equal(metric.description, 'Valid description');
+    t.equal(metric.timestamp, 1547507561724);
+    t.equal(metric.source, 'valid_source');
+    t.same(metric.labels, [{ name: 'foo', value: 5 }]);
+    t.equal(metric.value, 10);
+    t.equal(metric.type, 2);
+    t.equal(metric.meta, 'valid_meta');
+    t.equal(metric.name, 'valid_name');
+
+    t.end();
+});
+
+tap.test('Metric.toJSON() - only required arguments is set - should contain all properties with defaults', (t) => {
+    const clock = lolex.install();
+    clock.tick(1547507561724);
+
+    const metric = new Metric({
+        name: 'valid_name',
+        description: 'Valid description',
+    });
+
+    const serialized = metric.toJSON();
+
+    t.equal(serialized.description, 'Valid description');
+    t.equal(serialized.timestamp, (1547507561724 / 1000));
+    //    t.equal(serialized.source, null);
+    t.same(serialized.labels, []);
+    t.equal(serialized.value, null);
+    t.equal(serialized.type, 0);
+    t.equal(serialized.meta, null);
+    t.equal(metric.name, 'valid_name');
+
+    clock.uninstall();
+
+    t.end();
+});
+
+tap.test('Metric.toJSON() - all arguments is set - should contain all properties with set values', (t) => {
+    const metric = new Metric({
+        description: 'Valid description',
+        timestamp: 1547507561724,
+        source: 'valid_source',
+        labels: [{ name: 'foo', value: 5 }],
+        value: 10,
+        meta: 'valid_meta',
+        type: 2,
+        name: 'valid_name',
+    });
+
+    const serialized = metric.toJSON();
+
+    t.equal(serialized.description, 'Valid description');
+    t.equal(serialized.timestamp, 1547507561724);
+    //    t.equal(serialized.source, 'valid_source');
+    t.same(serialized.labels, [{ name: 'foo', value: 5 }]);
+    t.equal(serialized.value, 10);
+    t.equal(serialized.type, 2);
+    t.equal(serialized.meta, 'valid_meta');
+    t.equal(serialized.name, 'valid_name');
+
+    t.end();
+});
+
+
+tap.test('Metric.toPrimitive() - stringify - should includes all keys', (t) => {
     const metric = new Metric({
         name: 'valid_name',
         description: 'Valid description',
@@ -41,82 +187,12 @@ tap.test('stringifying includes all keys', (t) => {
     });
     t.equal(
         `${metric}`,
-        'Metric {"name":"valid_name","description":"Valid description","timestamp":12345,"type":0,"value":null,"time":null,"meta":{}}',
+        'Metric {"name":"valid_name","description":"Valid description","timestamp":12345,"type":0,"value":null,"labels":[],"meta":null}',
     );
     t.end();
 });
 
-tap.test('omitting required keys results in undefined instead of "null"', (t) => {
-    const metric = new Metric({
-        name: 'valid_name',
-    });
-    t.equal(metric.name, 'valid_name');
-    t.equal(metric.description, undefined);
-    t.equal(metric.timestamp, undefined);
-    t.equal(metric.type, 0);
-    t.equal(metric.time, null);
-    t.equal(metric.value, null);
-    t.same(metric.meta, {});
-    t.end();
-});
-
-tap.test('the number 0 is treated as a number and does not yeld "null"', (t) => {
-    const metric = new Metric({
-        name: 'valid_name',
-        value: 0,
-        type: 0,
-        timestamp: 0,
-    });
-    t.equal(metric.timestamp, 0);
-    t.equal(metric.type, 0);
-    t.equal(metric.value, 0);
-    t.end();
-});
-
-tap.test('empty string value is treated as "null"', (t) => {
-    const metric = new Metric({
-        name: 'valid_name',
-        value: '',
-    });
-    t.equal(metric.value, null);
-    t.end();
-});
-
-tap.test(
-    'empty string value, consist of multiple whitespaces, is treated as "null"',
-    (t) => {
-        const metric = new Metric({
-            name: 'valid_name',
-            value: '   ',
-        });
-        t.equal(metric.value, null);
-        t.end();
-    },
-);
-
-tap.test('util.inspect includes all keys', (t) => {
-    const metric = new Metric({
-        name: 'valid_name',
-        description: 'Valid description',
-        timestamp: 12345,
-        time: 12345,
-        value: 123,
-        meta: { key: 'value' },
-    });
-
-    const result = `Metric { name: 'valid_name',
-  description: 'Valid description',
-  timestamp: 12345,
-  type: 0,
-  value: 123,
-  time: 12345,
-  meta: { key: 'value' } }`;
-
-    t.equal(util.inspect(metric), result);
-    t.end();
-});
-
-tap.test('toStringTag includes Metric in name', (t) => {
+tap.test('Metric.toPrimitive() - stringify - should include "Metric" in name', (t) => {
     const metric = new Metric({
         name: 'valid_name',
         description: 'Valid description',
@@ -126,17 +202,9 @@ tap.test('toStringTag includes Metric in name', (t) => {
     t.end();
 });
 
-tap.test('toString outputs a full stringified object', (t) => {
-    const metric = new Metric({
-        name: 'valid_name',
-        description: 'Valid description',
-        timestamp: 12345,
-    });
-    t.equal(metric.toString(), '[object Metric]');
-    t.end();
-});
+tap.test('Metric.toPrimitive() - defaults - should throw', (t) => {
+    t.plan(1);
 
-tap.test('parseInt on metric instance outputs null', (t) => {
     const metric = new Metric({
         name: 'valid_name',
         description: 'Valid description',
@@ -145,6 +213,73 @@ tap.test('parseInt on metric instance outputs null', (t) => {
 
     t.throws(() => {
         const foo = metric + 1; // eslint-disable-line no-unused-vars
-    }, new Error('Invalid usage. Metric class instance cannot be treated as type "default"'));
+    }, /Invalid usage. Metric class instance cannot be treated as type "default"/);
+    t.end();
+});
+
+tap.test('Metric() - util.inspect - should includes all keys', (t) => {
+    const metric = new Metric({
+        name: 'valid_name',
+        description: 'Valid description',
+        timestamp: 12345,
+        value: 123,
+        meta: { key: 'value' },
+    });
+
+    const result = `Metric { name: 'valid_name',
+  description: 'Valid description',
+  timestamp: 12345,
+  type: 0,
+  value: 123,
+  labels: [],
+  meta: { key: 'value' } }`;
+
+    t.equal(util.inspect(metric), result);
+    t.end();
+});
+
+tap.test('Metric() - 0 values - should treat the number 0 as a number and not yeld "null"', (t) => {
+    const metric = new Metric({
+        name: 'valid_name',
+        description: 'Valid description',
+        value: 0,
+        type: 0,
+    });
+    t.equal(metric.type, 0);
+    t.equal(metric.value, 0);
+    t.end();
+});
+
+tap.test('Metric() - empty string - should be treated as "null"', (t) => {
+    const metric = new Metric({
+        name: 'valid_name',
+        description: 'Valid description',
+        source: '',
+    });
+    t.equal(metric.source, null);
+    t.end();
+});
+
+tap.test(
+    'Metric() - empty string, consist of multiple whitespaces - should be treated as "null"',
+    (t) => {
+        const metric = new Metric({
+            name: 'valid_name',
+            description: 'Valid description',
+            source: '     ',
+        });
+        t.equal(metric.source, null);
+        t.end();
+    },
+);
+
+tap.test('Metric.source - set value - should set the value', (t) => {
+    const metric = new Metric({
+        name: 'valid_name',
+        description: 'Valid description',
+        timestamp: 12345,
+    });
+    metric.source = 'foo';
+    t.equal(metric.source, 'foo');
     t.end();
 });


### PR DESCRIPTION
This PR does change the metric object in the following way:

 - All values in the object is now validated when set. We aim to follow the validation given in https://github.com/OpenObservability/OpenMetrics 
 - Validation is now done when a property is set, not when read as previously.
 - If validation fail it will now throw.
 - `.timestamp` does now default to generate a timestamp. Iow; `.timestamp` is not a required property any more.
 - `.labels` is now introduced in favour of `.meta`. It holds an Array where each item should be an Label object which has the following characteristics: `{ name: 'foo', value: 10 }`.
 - `.time` is deprecated but kept to secure backward compabillity.
 - `.meta` has changed to could hold any value. Its itended to be a field we can attach meta data to which is not part of the metric itself. Ex; hold quantiles information set up in the client and used by the collector.