### PR TITLE
Use symbol for time property

### DIFF
--- a/lib/metric.js
+++ b/lib/metric.js
@@ -85,7 +85,7 @@ const Metric = class Metric {
     }
 
     get time() {
-        return this._time;
+        return this[_time];
     }
 
     get meta() {

--- a/test/metric.js
+++ b/test/metric.js
@@ -187,7 +187,7 @@ tap.test('Metric.toPrimitive() - stringify - should includes all keys', (t) => {
     });
     t.equal(
         `${metric}`,
-        'Metric {"name":"valid_name","description":"Valid description","timestamp":12345,"type":0,"value":null,"labels":[],"meta":{}}',
+        'Metric {"name":"valid_name","description":"Valid description","timestamp":12345,"type":0,"value":null,"labels":[],"time":null,"meta":{}}',
     );
     t.end();
 });
@@ -232,7 +232,7 @@ tap.test('Metric() - util.inspect - should includes all keys', (t) => {
   type: 0,
   value: 123,
   labels: [],
-  time: undefined,
+  time: null,
   meta: { key: 'value' } }`;
 
     t.equal(util.inspect(metric), result);


### PR DESCRIPTION
The `time` property was wrongly referenced. It did not use the internal Symbol so returned value would always be `undefined`. Now using the correct Symbol for reference.